### PR TITLE
pin nix registry to prevent random downloads

### DIFF
--- a/m/Earthfile
+++ b/m/Earthfile
@@ -7,7 +7,7 @@ build:
     RUN /home/ubuntu/.nix-profile/bin/nix registry pin flake:nixpkgs
     RUN echo source $HOME/.nix-profile/share/nix-direnv/direnvrc > /home/ubuntu/.direnvrc
     RUN echo export DIRENV_LOG_FORMAT= >> /home/ubuntu/.bashrc
-    RUN echo export export DIRENV_WARN_TIMEOUT=300s >> /home/ubuntu/.bashrc
+    RUN echo export DIRENV_WARN_TIMEOUT=300s >> /home/ubuntu/.bashrc
     RUN git init && git config --global user.email "you@example.com" && git config --global user.name "Your Name"
     RUN mkdir -p /nix/cache /nix/cache/cache && rm -rf /home/ubuntu/.cache && ln -nfs /nix/cache/cache /home/ubuntu/.cache
     COPY . .

--- a/m/Earthfile
+++ b/m/Earthfile
@@ -4,7 +4,7 @@ build:
     FROM quay.io/defn/dev:latest-nix-installed
     ENTRYPOINT ["/home/ubuntu/.nix-profile/bin/nix", "develop", "--command", "bash", "-c"]
     CMD ["bash -il"]
-    RUN /home/ubuntu/.nix-profile/bin/nix registry ping flake:nixpkgs
+    RUN /home/ubuntu/.nix-profile/bin/nix registry pin flake:nixpkgs
     RUN echo source $HOME/.nix-profile/share/nix-direnv/direnvrc > /home/ubuntu/.direnvrc
     RUN echo export DIRENV_LOG_FORMAT= >> /home/ubuntu/.bashrc
     RUN echo export DIRENV_LOG_TIMEOUT=60 >> /home/ubuntu/.bashrc

--- a/m/Earthfile
+++ b/m/Earthfile
@@ -4,8 +4,10 @@ build:
     FROM quay.io/defn/dev:latest-nix-installed
     ENTRYPOINT ["/home/ubuntu/.nix-profile/bin/nix", "develop", "--command", "bash", "-c"]
     CMD ["bash -il"]
+    RUN /home/ubuntu/.nix-profile/bin/nix registry ping flake:nixpkgs
     RUN echo source $HOME/.nix-profile/share/nix-direnv/direnvrc > /home/ubuntu/.direnvrc
     RUN echo export DIRENV_LOG_FORMAT= >> /home/ubuntu/.bashrc
+    RUN echo export DIRENV_LOG_TIMEOUT=60 >> /home/ubuntu/.bashrc
     RUN git init && git config --global user.email "you@example.com" && git config --global user.name "Your Name"
     RUN mkdir -p /nix/cache /nix/cache/cache && rm -rf /home/ubuntu/.cache && ln -nfs /nix/cache/cache /home/ubuntu/.cache
     COPY . .

--- a/m/Earthfile
+++ b/m/Earthfile
@@ -7,7 +7,7 @@ build:
     RUN /home/ubuntu/.nix-profile/bin/nix registry pin flake:nixpkgs
     RUN echo source $HOME/.nix-profile/share/nix-direnv/direnvrc > /home/ubuntu/.direnvrc
     RUN echo export DIRENV_LOG_FORMAT= >> /home/ubuntu/.bashrc
-    RUN echo export export DIRENV_WARN_TIMEOUT=100y >> /home/ubuntu/.bashrc
+    RUN echo export export DIRENV_WARN_TIMEOUT=300s >> /home/ubuntu/.bashrc
     RUN git init && git config --global user.email "you@example.com" && git config --global user.name "Your Name"
     RUN mkdir -p /nix/cache /nix/cache/cache && rm -rf /home/ubuntu/.cache && ln -nfs /nix/cache/cache /home/ubuntu/.cache
     COPY . .

--- a/m/Earthfile
+++ b/m/Earthfile
@@ -7,7 +7,7 @@ build:
     RUN /home/ubuntu/.nix-profile/bin/nix registry pin flake:nixpkgs
     RUN echo source $HOME/.nix-profile/share/nix-direnv/direnvrc > /home/ubuntu/.direnvrc
     RUN echo export DIRENV_LOG_FORMAT= >> /home/ubuntu/.bashrc
-    RUN echo export DIRENV_LOG_TIMEOUT=60 >> /home/ubuntu/.bashrc
+    RUN echo export export DIRENV_WARN_TIMEOUT=100y >> /home/ubuntu/.bashrc
     RUN git init && git config --global user.email "you@example.com" && git config --global user.name "Your Name"
     RUN mkdir -p /nix/cache /nix/cache/cache && rm -rf /home/ubuntu/.cache && ln -nfs /nix/cache/cache /home/ubuntu/.cache
     COPY . .


### PR DESCRIPTION
increase direnv timeout before it emits a warning as nix flakes can takea while to build

Test: `cd m; make image shell`

