### PR TITLE
use coder ssh key to access github repositories

### DIFF
--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -1,2 +1,0 @@
-[url "git@github.com:"]
-    insteadOf = https://github.com/


### PR DESCRIPTION
Set GIT_SSH_COMMAND to coder if it isn't already set.  This allows Coder to use its ssh key to access GitHub repos, avoiding the https:// login helper.