### PR TITLE
fix: release type is simple, configure extra-files

### DIFF
--- a/.github/workflows/please-release.yaml
+++ b/.github/workflows/please-release.yaml
@@ -15,5 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,14 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": true,
+  "release-type": "simple",
   "packages": {
     ".": {
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "version.txt"
-        }
-      ]
+      "extra-files": ["version"]
     }
   }
 }

--- a/version
+++ b/version
@@ -1,0 +1,1 @@
+x-release-please-version

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-x-release-please-start-version
+1.0.0


### PR DESCRIPTION
Set the release type to simple since something defaults to node.

Configure extra-files as a list.

Partially implements #25 