### PR TITLE
fix: wrapper kubectl-oidc_login for kubelogin

### DIFF
--- a/bin/kubectl-oidc_login
+++ b/bin/kubectl-oidc_login
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec kubelogin "$@"


### PR DESCRIPTION
fixes #71 

Went with a bash wrapper because the ideal solution of `mise` renaming the `kubelogin` binary does not work.  This is a workaround.
