### PR TITLE
feat: upgrade mise managed tools

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -3,18 +3,18 @@ experimental = true
 
 [tools]
 ansible = "11.3.0"
-aws = "2.24.23"
+aws = "2.25.1"
 aws-vault = "7.2.0"
 bazelisk = "1.25.0"
-coder = "2.20.0"
+coder = "2.20.2"
 cue = "0.12.0"
-gh = "2.68.1"
+gh = "2.69.0"
 jq = "1.7.1"
 just = "1.40.0"
 pipx = "1.7.1"
 python = "3.13.2"
 starship = "1.22.1"
-"ubi:coder/code-server" = { version = "4.98.0", bin_path = "bin", extract_all = "true" }
+"ubi:coder/code-server" = { version = "4.98.2", bin_path = "bin", extract_all = "true" }
 "ubi:honeycombio/buildevents" = "0.17.0"
 "ubi:peak/s5cmd" = "2.3.0"
-"ubi:railwayapp/railpack" = "0.0.53"
+"ubi:railwayapp/railpack" = "0.0.57"

--- a/m/mise.toml
+++ b/m/mise.toml
@@ -4,6 +4,6 @@ helm = "3.17.2"
 k3d = "5.8.3"
 kubectl = "1.32.3"
 kustomize = "5.6.0"
-node = "23.9.0"
+node = "23.10.0"
 "ubi:bazelbuild/buildtools" = { version = "8.0.3", exe = "buildifier" }
-"ubi:int128/kubelogin" = { version = "1.32.2", rename_exe = "kubectl-oidc_login" }
+"ubi:int128/kubelogin" = { version = "1.32.3", rename_exe = "kubectl-oidc_login" }


### PR DESCRIPTION
also fixes #93 

Upgrade the global and `m/` mise managed tools.

Upgrade process:
```
cd ~/m
mise upgrade --bump
```

Since `code-server` updated, the browser opening commands didn't work because the PATH to code-server changed.  Restarted `code-server`.  The `setsid` detaches the command because the IDE will be unavailable as `code-server` restarts.  Refresh browser in a bit when the new `code-server` comes up.
```
setsid s6-svc -r ~/m/svc/code-server &
```
