### PR TITLE
fix: warn if locked-down mode is enabled

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -49,7 +49,7 @@ disabled = false
 disabled = true
 
 [custom.lockdown]
-command = 'if test "$(defaults read .GlobalPreferences.plist LDMGlobalEnabled)" != "1"; then echo not-locked-down; fi'
+command = 'if test "$(defaults read .GlobalPreferences.plist LDMGlobalEnabled)" == "1"; then echo locked-down; fi'
 when = ''' test "$(uname -s)" == "Darwin" '''
 format = '[$output]($style) '
 


### PR DESCRIPTION
fixed #105 

Searched for `locked.down` to find the warning is in the Starship prompt config.  Changed the test to warn if locked-down mode is enabled.
