### PR TITLE
fix: comment out GSSAPIAuthentication in ssh client config

### DIFF
--- a/fixup.sh
+++ b/fixup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -efu -o pipefail
+
+function main {
+	sudo perl -pe 's{^\s*GSSAPIAuthentication}{#GSSAPIAuthentication}' -i /etc/ssh/ssh_config
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,8 @@ function main {
 
 	make sync
 	make install
+
+	./fixup.sh
 }
 
 main "$@"


### PR DESCRIPTION
fixed #58 

The ssh error is:
```
❯ ssh thinkpad uname -a
/etc/ssh/ssh_config line 53: Unsupported option "gssapiauthentication"
```

Grepping for `gssapiauthentication` didn't find anything in `/etc/ssh/ssh_config` because line 53 actually has `GSSAPIAuthentication` as the option name.  

This PR comments out that line by looking for the start of the line, with optional whitespace, then `GSSAPIAuthentication` and replacing it with `#GSSAPIAuthentication`.

