### PR TITLE
fix: ping capabilities so it can work

### DIFF
--- a/fixup.sh
+++ b/fixup.sh
@@ -4,6 +4,8 @@ set -efu -o pipefail
 
 function main {
 	sudo perl -pe 's{^\s*GSSAPIAuthentication}{#GSSAPIAuthentication}' -i /etc/ssh/ssh_config
+
+	sudo setcap cap_net_raw+p $(readlink $(which ping))
 }
 
 main "$@"


### PR DESCRIPTION
fixes #99 

The error message for nix installed ping is:
```
❯ ping thinkpad
ping: socktype: SOCK_RAW
ping: socket: Operation not permitted
ping: => missing cap_net_raw+p capability or setuid?
```

Using `setuid` is out because that grants all root privileges.  Went with the missing capabilities.

Since Nix `ping` is a symlink, the capabilities have to be applied to what the symlink is pointing to.  A combination of `which` to find `ping`, then `readlink` to find where `ping` symlinks points to, allows for the use of `setcap` to grant the capabilities to the real `ping` command.
