### PR TITLE
fix: remove docker pass, secretservice credential providers

### DIFF
--- a/fixup.sh
+++ b/fixup.sh
@@ -6,6 +6,8 @@ function main {
 	sudo perl -pe 's{^\s*GSSAPIAuthentication}{#GSSAPIAuthentication}' -i /etc/ssh/ssh_config
 
 	sudo setcap cap_net_raw+p $(readlink $(which ping))
+
+	for a in docker-credential-{pass,secretservice}; do rm -vf "$(which "$a")"; done
 }
 
 main "$@"


### PR DESCRIPTION
fixes #92 

Docker credential providers are named with prefix `docker-credential`.  Tab complete the names for the `pass` and `secretservice` providers.

Loop over the names, then delete the full path as returned by `which`.

This removal is not clean because the package should be removed, but that should be fixed in the base image.  When fixing an existing system, a fixup is acceptable.
