### PR TITLE
fix: docker socket accessible by ubuntu user

### DIFF
--- a/fixup.sh
+++ b/fixup.sh
@@ -8,6 +8,13 @@ function main {
 	sudo setcap cap_net_raw+p $(readlink $(which ping))
 
 	for a in docker-credential-{pass,secretservice}; do rm -vf "$(which "$a")"; done
+
+	if ! test -e .docker/config.json; then
+		cp .docker/config.json.example .docker/config.json
+	fi
+
+	sudo chgrp ubuntu /var/run/docker.sock
+	sudo usermod -aG docker ubuntu
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -14,10 +14,6 @@ function main {
 		iproute2 iptables bc pv socat docker.io s6 cpu-checker bind9-dnsutils \
 		pass
 	
-	if ! test -e .docker/config.json; then
-		cp .docker/config.json.example .docker/config.json
-	fi
-
 	source .bash_profile
 
 	make sync

--- a/m/Dockerfile
+++ b/m/Dockerfile
@@ -15,7 +15,6 @@ RUN apt update && apt install -y \
 RUN curl -fsSL https://tailscale.com/install.sh | sh
 
 RUN if [ "$(id -u ubuntu)" != 1000 ]; then groupadd -r --gid 1000 ubuntu && useradd -m -s /bin/bash -g ubuntu --uid 1000 ubuntu; fi
-RUN usermod -aG docker ubuntu
 
 RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 

--- a/m/i/script/001-install-base
+++ b/m/i/script/001-install-base
@@ -41,6 +41,7 @@ EOF
 
 	groupadd -g 1000 ubuntu && useradd -u 1000 -d /home/ubuntu -s /bin/bash -g ubuntu -M ubuntu
 
+	# need docker accessible because install.sh won't be run in the AMI
 	usermod -aG docker ubuntu
 
 	echo 'ubuntu ALL=(ALL:ALL) NOPASSWD: ALL' >/etc/sudoers.d/ubuntu


### PR DESCRIPTION
fixes #94 

The `fixup.sh` script will grant access to Docker socket to the `ubuntu` user via two fixes:
- immediately by changing the group of the docket to `ubuntu`
- long term by adding `ubuntu` user to the `docker` group, which will take effect during the next restart or update.  This restart/update will revert the immediate socket group ownership back to `docker`
