### PR TITLE
fix: mount /dev/net/tun for tailscale in m/dc

### DIFF
--- a/m/dc/docker-compose.yaml
+++ b/m/dc/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     privileged: true
     devices:
       - "/dev/kvm:/dev/kvm"
+      - "/dev/net/tun:/dev/net/tun"
     cap_add:
       - NET_ADMIN
     security_opt:


### PR DESCRIPTION
fixes #95 

In the docker compose configuration in `m/dc`, mount `/dev/net/tun` so `tailscaled` can function.
