### PR TITLE
feat: m adhoc task to create an issue and work on it

### DIFF
--- a/.config/mise/tasks/adhoc
+++ b/.config/mise/tasks/adhoc
@@ -16,7 +16,7 @@ gh issue create --assignee '@me' --title "${usage_title}" --body ''
 issue=
 while test -z "${issue}"; do
 	sleep 1
-	issue="$(gh issue ls --search "${usage_title}" --json number | jq -r '.[0].number' )"
+	issue="$(gh issue ls --search "${usage_title}" --json number | jq -r '.[0].number // ""' )"
 done
 
 # let m work check out the issue branch


### PR DESCRIPTION
fixes #138 

New task `m adhoc` creates an issue, then retrieves the issue number so `m work` can create the branch.  Follow up with `m pr` to finish.  This flow is smooth, writing up the issue and PR can be done later.
