### PR TITLE
feat: tagged release images

### DIFF
--- a/m/Dockerfile
+++ b/m/Dockerfile
@@ -2,15 +2,20 @@ FROM ubuntu:noble-20250127
 
 ARG GITHUB_TOKEN
 ARG NIX_CONFIG
+ARG RELEASE
+
+RUN echo "$RELEASE"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # sync with install.sh, m/i/script/001-install-base
-RUN apt update && apt install -y \
-    make direnv curl xz-utils dirmngr gpg pcscd scdaemon gpg-agent rsync \
-    build-essential sudo ca-certificates tzdata locales git git-lfs tini \
-    iproute2 iptables bc pv socat docker.io s6 cpu-checker bind9-dnsutils \
-    pass
+RUN apt update \
+    && apt upgrade -y \
+    && apt install -y \
+        make direnv curl xz-utils dirmngr gpg pcscd scdaemon gpg-agent rsync \
+        build-essential sudo ca-certificates tzdata locales git git-lfs tini \
+        iproute2 iptables bc pv socat docker.io s6 cpu-checker bind9-dnsutils \
+        pass
 
 RUN curl -fsSL https://tailscale.com/install.sh | sh
 

--- a/m/Dockerfile.latest
+++ b/m/Dockerfile.latest
@@ -1,5 +1,5 @@
-ARG BUILD_TAG
+ARG RELEASE
 
-FROM quay.io/defn/dev:${BUILD_TAG}
+FROM quay.io/defn/dev:${RELEASE}
 
 RUN bin/with-env make sync

--- a/m/Justfile
+++ b/m/Justfile
@@ -27,12 +27,13 @@ up:
 base:
 	GITHUB_TOKEN="$(just github::token)" \
 	BUILD_SHA="$(git rev-parse HEAD)" \
-	BUILD_TAG="$(git describe --tags --exact-match 2>&- || echo base)" \
-		&& docker build -t quay.io/defn/dev:${BUILD_TAG}-inner \
+	RELEASE="$(git describe --tags --abbrev=0)" \
+		&& docker build -t quay.io/defn/dev:${RELEASE} \
+			--build-arg RELEASE="$RELEASE" \
 			--build-arg GITHUB_TOKEN="$GITHUB_TOKEN" \
 			--build-arg NIX_CONFIG="access-tokens = github.com=$GITHUB_TOKEN" \
 			. \
-		&& docker build --no-cache -t quay.io/defn/dev:${BUILD_TAG} -f Dockerfile.latest \
-			--build-arg BUILD_TAG="${BUILD_TAG}-inner" \
+		&& docker build --no-cache -t quay.io/defn/dev:base -f Dockerfile.latest \
+			--build-arg RELEASE="${RELEASE}" \
 			. \
-		&& docker push quay.io/defn/dev:${BUILD_TAG} 
+		&& docker push quay.io/defn/dev:base


### PR DESCRIPTION
fixes #155 

The inner image is tagged with the release.  It is large and cached, rebuilds when release changes.

The ultimate image is the base image, which should be an incremental build with just `make sync` and similarly fast updates.

