### PR TITLE
fix: push release-tagged docker images

### DIFF
--- a/m/Justfile
+++ b/m/Justfile
@@ -37,4 +37,5 @@ base:
 		&& docker build --no-cache -t ghcr.io/defn/dev:base -f Dockerfile.latest \
 			--build-arg RELEASE="${RELEASE}" \
 			. \
+		&& docker push ghcr.io/defn/dev:${RELEASE} \
 		&& docker push ghcr.io/defn/dev:base


### PR DESCRIPTION
fixes #159 

When building the image with `j base` in `m/`, push the released-tagged image in addition to pushing the base tag image.

![image](https://github.com/user-attachments/assets/0a6d0faf-a8d7-47c6-a53b-16634c684777)
