### PR TITLE
feat: m tasks to manage s6

### DIFF
--- a/.config/mise/tasks/activate
+++ b/.config/mise/tasks/activate
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#MISE description="Activate new services"
+#USAGE arg "path" help="Path to a service directory" default=""
+
+set -efu -o pipefail
+
+cd "${MISE_ORIGINAL_CWD}"
+
+if [[ -n "${usage_path}" ]]; then
+	cd "${usage_path}"
+fi
+
+s6-svscanctl -a .

--- a/.config/mise/tasks/log
+++ b/.config/mise/tasks/log
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+#MISE description="View logs for an s6 service"
+#USAGE arg "path" help="Path to a service directory" default=""
+
+set -efu -o pipefail
+
+cd "${MISE_ORIGINAL_CWD}"
+
+if [[ -n "${usage_path}" ]]; then
+	cd "${usage_path}"
+fi
+
+case "$(basename "$(pwd)")" in
+	svc)
+		echo "ERROR: s6-svscandir log not implemented" 1>&2
+		exit 1
+		;;
+	*)
+		tail -f log/current
+		;;
+esac

--- a/.config/mise/tasks/restart
+++ b/.config/mise/tasks/restart
@@ -13,19 +13,14 @@ fi
 
 case "$(basename "$(pwd)")" in
 	svc)
-		cd ..
-		mise run serve		
+		echo "ERROR: s6-svscandir restart not implemented" 1>&2
+		exit 1
 		;;
 	*)
-		if ! s6-svstat . >/dev/null 2>&1; then
-			cd $(pwd)/../../svc && mise run activate
-			while ! s6-svstat .; do
-				sleep 1
-			done
-		fi
-		s6-svc -u .
-		while ! s6-svstat . | grep ^up; do
+		s6-svc -d .
+		while ! s6-svstat . | grep ^down; do
 			sleep 1
 		done
+		mise run start
 		;;
 esac

--- a/.config/mise/tasks/restart
+++ b/.config/mise/tasks/restart
@@ -17,10 +17,7 @@ case "$(basename "$(pwd)")" in
 		exit 1
 		;;
 	*)
-		s6-svc -d .
-		while ! s6-svstat . | grep ^down; do
-			sleep 1
-		done
+		mise run stop
 		mise run start
 		;;
 esac

--- a/.config/mise/tasks/start
+++ b/.config/mise/tasks/start
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#MISE description="Start an s6 service"
+#USAGE arg "path" help="Path to a service directory" default=""
+
+set -efu -o pipefail
+
+cd "${MISE_ORIGINAL_CWD}"
+
+if [[ -n "${usage_path}" ]]; then
+	cd "${usage_path}"
+fi
+
+case "$(basename "$(pwd)")" in
+	svc)
+		cd ..
+		mise run serve		
+		;;
+	*)
+		s6-svc -u .
+		s6-svstat .
+		;;
+esac

--- a/.config/mise/tasks/status
+++ b/.config/mise/tasks/status
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+#MISE description="Get the status of an s6 service"
+#USAGE arg "path" help="Path to a service directory" default=""
+
+set -efu -o pipefail
+
+cd "${MISE_ORIGINAL_CWD}"
+
+if [[ -n "${usage_path}" ]]; then
+	cd "${usage_path}"
+fi
+
+case "$(basename "$(pwd)")" in
+	svc)
+		echo "ERROR: s6-svscan status not implemented" 1>&2
+		exit 1
+		;;
+	*)
+		s6-svstat .
+		;;
+esac

--- a/.config/mise/tasks/status
+++ b/.config/mise/tasks/status
@@ -13,8 +13,9 @@ fi
 
 case "$(basename "$(pwd)")" in
 	svc)
-		echo "ERROR: s6-svscan status not implemented" 1>&2
-		exit 1
+		set +f
+		runmany 'cd $1 && echo "$(basename $(pwd)) $(mise run status 2>/dev/null)"' */ | sort | talign 2
+		set -f
 		;;
 	*)
 		s6-svstat .

--- a/.config/mise/tasks/stop
+++ b/.config/mise/tasks/stop
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#MISE description="Start an s6 service"
+#MISE description="Stop an s6 service"
 #USAGE arg "path" help="Path to a service directory" default=""
 
 set -efu -o pipefail
@@ -14,17 +14,12 @@ fi
 case "$(basename "$(pwd)")" in
 	svc)
 		cd ..
-		mise run serve		
+		echo "ERROR: s6-svscandir stop not implemented" 1>&2
+		exit 1
 		;;
 	*)
-		if ! s6-svstat . >/dev/null 2>&1; then
-			cd $(pwd)/../../svc && mise run activate
-			while ! s6-svstat .; do
-				sleep 1
-			done
-		fi
-		s6-svc -u .
-		while ! s6-svstat . | grep ^up; do
+		s6-svc -d .
+		while ! s6-svstat . | grep ^down; do
 			sleep 1
 		done
 		;;

--- a/m/svc.d/main/run
+++ b/m/svc.d/main/run
@@ -2,4 +2,4 @@
 
 exec 2>&1
 
-exec mise run up
+exec sleep infinity


### PR DESCRIPTION
fixes #163 

implements `m` tasks to manage `svc` and its service directories.

- `m activate` only works in `svc`
- `m start` works in `svc` and service dirs
- `m status` works in `svc` and service dirs
- `m stop` only works service dirs
- `m restart` only works service dirs

Notes:
- `m start` in a service dir that hasn't been activated, will activate all services in `svc` first
