### PR TITLE
feat: upgrade mise when running make sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,7 @@ sync:
 	$(MAKE) sync_inner
 
 sync_inner:
+	mise self-update --yes
 	git ls-files | grep 'mise.toml$$' | runmany 'mise trust $$1'
 	mise install
 	(cd m && mise install)


### PR DESCRIPTION
upgrading mise in `make sync` is more useful as `make mise-upgrade` is only run occasionally.